### PR TITLE
Return the mutated response

### DIFF
--- a/src/HelloWorld.php
+++ b/src/HelloWorld.php
@@ -47,6 +47,6 @@ class HelloWorld
         $response->getBody()
             ->write("<html><head></head><body>Hello, {$this->foo} world!</body></html>");
 
-        return $this->response;
+        return $response;
     }
 }


### PR DESCRIPTION
When `HelloWorld` is invoked it is returning the response originally injected into the class.  We should return the mutated response with our HTML body instead.