### PR TITLE
Require PHP 8.1

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,3 +1,3 @@
 FROM gitpod/workspace-full:2022-08-17-18-37-55
 
-RUN sudo update-alternatives --set php $(which php8.0)
+RUN sudo update-alternatives --set php $(which php8.1)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A fully-functional example app bootstrap built to accompany the [Modern PHP With
 
 ## License
 
-Copyright 2022 Kevin Smith
+Copyright 2023 Kevin Smith
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "laminas/laminas-diactoros": "^2.9",
         "middlewares/fast-route": "^2.0",
         "middlewares/request-handler": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb2f434924aaef849fb45ceed64fd05a",
+    "content-hash": "8c6e89c866f8a8f40832a46c0e16c947",
     "packages": [
         {
             "name": "laminas/laminas-diactoros",
@@ -1130,7 +1130,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.0"
+        "php": ">=8.1"
     },
     "platform-dev": [],
     "plugin-api-version": "2.2.0"


### PR DESCRIPTION
Now that 8.0 is in security support, it makes sense to require PHP 8.1.